### PR TITLE
Add RSI(14) price divergence scanner (bullish/bearish)

### DIFF
--- a/pkscreener/classes/ConsoleMenuUtility.py
+++ b/pkscreener/classes/ConsoleMenuUtility.py
@@ -158,7 +158,7 @@ class PKConsoleMenuTools:
                     + colorText.END
                 ) or "3"
             )
-            if resp >= 0 and resp <= 10:
+            if resp >= 0 and resp <= 11:
                 if resp == 4:
                     try:
                         defaultMALength = 9 if PKConsoleMenuTools.configManager.duration.endswith("m") else 50

--- a/pkscreener/classes/MenuOptions.py
+++ b/pkscreener/classes/MenuOptions.py
@@ -607,6 +607,7 @@ level3_X_Reversal_MenuDict = {
     "8": "PSAR and RSI reversal",
     "9": "Rising RSI",
     "10": "RSI MA Reversal",
+    "11": "RSI(14) Divergence (Bullish/Bearish)",
 
     "0": "Cancel",
 }

--- a/pkscreener/classes/ScreeningStatistics.py
+++ b/pkscreener/classes/ScreeningStatistics.py
@@ -4740,7 +4740,62 @@ class ScreeningStatistics:
             saveDict['MA-Signal'] = saved[1] + f'RSI-MA-Sell'
             return True if (rsiKey == "RSIi") else (self.findRSICrossingMA(df, screenDict, saveDict,lookFor=lookFor, maLength=maLength, rsiKey="RSIi") or True)
         return False if (rsiKey == "RSIi") else (self.findRSICrossingMA(df, screenDict, saveDict,lookFor=lookFor, maLength=maLength, rsiKey="RSIi"))
-    
+
+    # Find price/RSI(14) divergence using swing highs/lows.
+    # Bullish: price makes a lower low while RSI makes a higher low (momentum fading on the downside).
+    # Bearish: price makes a higher high while RSI makes a lower high (momentum fading on the upside).
+    def findRSIDivergence(self, df, screenDict=None, saveDict=None, lookFor=3, lookback=14, rsiKey="RSI"):
+        if df is None or len(df) == 0:
+            return False
+        if rsiKey not in df.columns or "close" not in df.columns:
+            return False
+        data = df.copy()
+        data = data[::-1]  # oldest first, so swings read left-to-right in time
+        data = data.tail(lookback + 4)
+        if len(data) < 9:
+            return False
+        closes = data["close"].to_numpy()
+        rsis = data[rsiKey].to_numpy()
+        n = len(closes)
+        order = 2  # a bar must be the extreme within +/- `order` bars to count as a swing point
+
+        def swingIndices(values, findHigh):
+            indices = []
+            for i in range(order, n - order):
+                window = values[i - order:i + order + 1]
+                if (findHigh and values[i] == window.max()) or (not findHigh and values[i] == window.min()):
+                    indices.append(i)
+            return indices
+
+        foundBullish = False
+        foundBearish = False
+
+        if lookFor in [1, 3]:
+            lows = swingIndices(closes, findHigh=False)
+            if len(lows) >= 2:
+                i1, i2 = lows[-2], lows[-1]
+                if closes[i2] < closes[i1] and rsis[i2] > rsis[i1]:
+                    foundBullish = True
+                    if screenDict is not None and saveDict is not None:
+                        saved = self.findCurrentSavedValue(screenDict, saveDict, "Pattern")
+                        label = f"Bullish RSI({lookback}) Divergence"
+                        screenDict["Pattern"] = saved[0] + colorText.GREEN + label + colorText.END
+                        saveDict["Pattern"] = saved[1] + label
+
+        if lookFor in [2, 3]:
+            highs = swingIndices(closes, findHigh=True)
+            if len(highs) >= 2:
+                i1, i2 = highs[-2], highs[-1]
+                if closes[i2] > closes[i1] and rsis[i2] < rsis[i1]:
+                    foundBearish = True
+                    if screenDict is not None and saveDict is not None:
+                        saved = self.findCurrentSavedValue(screenDict, saveDict, "Pattern")
+                        label = f"Bearish RSI({lookback}) Divergence"
+                        screenDict["Pattern"] = saved[0] + colorText.FAIL + label + colorText.END
+                        saveDict["Pattern"] = saved[1] + label
+
+        return foundBullish or foundBearish
+
     def findRSRating(self, stock_rs_value=-1, index_rs_value=-1,df=None,screenDict={}, saveDict={}):
         if stock_rs_value <= 0:
             stock_rs_value = self.calc_relative_strength(df=df)

--- a/pkscreener/classes/StockScreener.py
+++ b/pkscreener/classes/StockScreener.py
@@ -386,7 +386,13 @@ class StockScreener:
                     if not isValidRsi:
                         return returnLegibleData(f"isValidRsi:{isValidRsi}")
                 elif executeOption == 6:
-                    if reversalOption == 10:
+                    if reversalOption == 11:
+                        hasRSIDivergence = screener.findRSIDivergence(processedData,
+                                                                       screeningDictionary,
+                                                                       saveDictionary) # 1 =Bullish, 2 =Bearish, 3 = Either
+                        if not hasRSIDivergence:
+                            return returnLegibleData(f"hasRSIDivergence:{hasRSIDivergence}")
+                    elif reversalOption == 10:
                         hasRSIMAReversal = screener.findRSICrossingMA(processedData,
                                                                       screeningDictionary,
                                                                       saveDictionary,

--- a/test/ScreeningStatistics_test.py
+++ b/test/ScreeningStatistics_test.py
@@ -4339,6 +4339,50 @@ class TestRSIMethods(unittest.TestCase):
         result = self.stats.findRSICrossingMA(df, screenDict, saveDict, lookFor=1, maLength=5)
         self.assertIsInstance(result, (bool, np.bool_))
 
+    def test_findRSIDivergence_bullish(self):
+        """Test findRSIDivergence detects a bullish divergence (price lower low, RSI higher low)."""
+        closes_oldest_first = [100,98,96,94,92,94,96,98,100,96,92,86,90,94,96,98,100,102]
+        rsis_oldest_first = [50,45,40,35,30,35,40,45,50,45,38,40,45,50,55,58,60,62]
+        df = pd.DataFrame({
+            'close': list(reversed(closes_oldest_first)),
+            'RSI': list(reversed(rsis_oldest_first)),
+        })
+        screenDict = {}
+        saveDict = {}
+        result = self.stats.findRSIDivergence(df, screenDict, saveDict, lookFor=1, lookback=14)
+        self.assertTrue(result)
+        self.assertIn('Bullish', saveDict.get('Pattern', ''))
+
+    def test_findRSIDivergence_bearish(self):
+        """Test findRSIDivergence detects a bearish divergence (price higher high, RSI lower high)."""
+        closes_oldest_first = [100,102,104,106,108,106,104,102,100,104,108,114,110,106,104,102,100,98]
+        rsis_oldest_first = [50,55,60,65,70,65,60,55,50,55,62,60,55,50,45,42,40,38]
+        df = pd.DataFrame({
+            'close': list(reversed(closes_oldest_first)),
+            'RSI': list(reversed(rsis_oldest_first)),
+        })
+        screenDict = {}
+        saveDict = {}
+        result = self.stats.findRSIDivergence(df, screenDict, saveDict, lookFor=2, lookback=14)
+        self.assertTrue(result)
+        self.assertIn('Bearish', saveDict.get('Pattern', ''))
+
+    def test_findRSIDivergence_none(self):
+        """Test findRSIDivergence returns False when price and RSI trend together (no divergence)."""
+        closes = list(range(100, 118))
+        rsis = list(range(40, 58))
+        df = pd.DataFrame({'close': closes, 'RSI': rsis})
+        result = self.stats.findRSIDivergence(df, {}, {}, lookFor=3, lookback=14)
+        self.assertFalse(result)
+
+    def test_findRSIDivergence_invalid_input(self):
+        """Test findRSIDivergence handles missing columns, empty and short dataframes gracefully."""
+        self.assertFalse(self.stats.findRSIDivergence(None, {}, {}))
+        self.assertFalse(self.stats.findRSIDivergence(pd.DataFrame(), {}, {}))
+        self.assertFalse(self.stats.findRSIDivergence(pd.DataFrame({'close': [1, 2, 3]}), {}, {}))
+        shortDf = pd.DataFrame({'close': [100, 99, 98], 'RSI': [40, 42, 44]})
+        self.assertFalse(self.stats.findRSIDivergence(shortDf, {}, {}))
+
     def test_findRSRating(self):
         """Test findRSRating method."""
         df = pd.DataFrame({'close': [100, 102, 104, 106, 108]})


### PR DESCRIPTION
## Summary
Closes #172.

Adds a genuine price-vs-RSI(14) divergence detector, rather than the existing RSI-overbought/oversold proxy used in `addBearishSellSignals`:

- **Bullish divergence**: price makes a lower swing low while RSI makes a higher swing low (downside momentum fading — potential reversal up).
- **Bearish divergence**: price makes a higher swing high while RSI makes a lower swing high (upside momentum fading — potential reversal down).

Swing points are detected as local extremes within a small rolling window (order=2) over the lookback period, then the two most recent swing points of each type are compared.

## Where it's wired in
- New `ScreeningStatistics.findRSIDivergence(df, screenDict, saveDict, lookFor=3, lookback=14, rsiKey="RSI")` — `lookFor`: 1=bullish, 2=bearish, 3=either. Records the label into `screenDict`/`saveDict["Pattern"]` following the existing convention used by other pattern detectors in the class.
- New Reversal Scan menu option `11` ("RSI(14) Divergence (Bullish/Bearish)") in `MenuOptions.py`.
- Dispatch wired in `StockScreener.py` under `executeOption == 6` (Reversal scans), alongside the existing PSAR/RSI-MA/Rising-RSI options.
- `ConsoleMenuUtility.promptReversalScreening` range check extended from `<= 10` to `<= 11` so the new menu item is selectable interactively (it needs no extra sub-prompt, same as options 8/9).

## Testing
- Added `test_findRSIDivergence_bullish`, `test_findRSIDivergence_bearish`, `test_findRSIDivergence_none`, `test_findRSIDivergence_invalid_input` to `test/ScreeningStatistics_test.py` — all pass.
- Ran the full `test/ScreeningStatistics_test.py` suite before and after this change: same 26 pre-existing failures on both (missing `pkg_resources`/`pandas_ta_classic` modules and a few environment-dependent assertions unrelated to this change), with 4 additional passing tests from this PR and no regressions (497 passed baseline → 501 passed with this change, both with the same 26 failures).
- `flake8 --select=E9,F63,F7,F82` clean on all changed files.

## Notes / possible follow-up
- Kept scope focused on the daily RSI(14) case per the issue title. The existing RSI methods in this file recurse into an intraday `"RSIi"` variant for feature parity — happy to add that in a follow-up or in this PR if preferred.