### PR TITLE
feat: add Darvas Box breakout scanner

### DIFF
--- a/pkscreener/classes/ScreeningStatistics.py
+++ b/pkscreener/classes/ScreeningStatistics.py
@@ -4255,6 +4255,65 @@ class ScreeningStatistics:
         is_near = min_dist <= threshold_pct
         return is_near, extension_levels, nearest, min_dist * 100
 
+    def findDarvasBoxBreakout(self, df, lookback_periods=20, min_box_pct=2.0, max_box_pct=25.0,
+                               high_col='high', low_col='low', close_col='close'):
+        """
+        Detect a Darvas Box formation and any breakout/breakdown from it.
+
+        The box is formed from the historical window *excluding* the most
+        recent (today's) row, so that today's own high/close can be
+        evaluated against it as a potential breakout:
+          - Box top: the swing high within the historical window.
+          - Box bottom: the lowest low reached since that swing high, i.e.
+            the consolidation low that followed the peak.
+
+        Returns:
+            (is_breakout, box_top, box_bottom, box_range_pct, direction)
+            direction is 'up' for today's close above box_top, 'down' for a
+            close below box_bottom, or None if price is still inside the box
+            or no valid box could be formed (e.g. box size outside
+            [min_box_pct, max_box_pct]).
+        """
+        if df is None or len(df) < 3:
+            return False, None, None, 0, None
+
+        data = df.copy()
+        # Data is newest-first; reset to a plain positional index so we can
+        # safely slice by position. Row 0 is "today" and is excluded from
+        # box formation — the box must already exist before today's move.
+        window = data.head(lookback_periods + 1) if lookback_periods else data
+        window = window.reset_index(drop=True)
+        if len(window) < 3:
+            return False, None, None, 0, None
+
+        current_close = window.loc[0, close_col]
+        historical = window.iloc[1:].reset_index(drop=True)
+
+        box_top_pos = historical[high_col].idxmax()
+        box_top = historical.loc[box_top_pos, high_col]
+        # Rows from the most recent historical row up to and including the
+        # swing high — the consolidation that followed the peak.
+        post_peak = historical.iloc[: box_top_pos + 1]
+        if len(post_peak) < 2:
+            return False, box_top, None, 0, None
+
+        box_bottom = post_peak[low_col].min()
+        if box_bottom <= 0 or box_top <= box_bottom:
+            return False, box_top, box_bottom, 0, None
+
+        box_range_pct = (box_top - box_bottom) / box_bottom * 100
+        if box_range_pct < min_box_pct or box_range_pct > max_box_pct:
+            return False, box_top, box_bottom, box_range_pct, None
+
+        direction = None
+        if current_close > box_top:
+            direction = "up"
+        elif current_close < box_bottom:
+            direction = "down"
+
+        is_breakout = direction is not None
+        return is_breakout, box_top, box_bottom, box_range_pct, direction
+
     def findHigherBullishOpens(self, df):
         if df is None or len(df) == 0:
             return False

--- a/test/ScreeningStatistics_test.py
+++ b/test/ScreeningStatistics_test.py
@@ -3814,6 +3814,49 @@ class TestUncoveredMethods(unittest.TestCase):
         result = self.stats.findHigherBullishOpens(df)
         self.assertIsNotNone(result)
 
+    def test_findDarvasBoxBreakout_breaks_above_box_top(self):
+        """A close above the historical box top should report an 'up' breakout."""
+        # Newest-first: row 0 is "today", breaking out above box_top=110.
+        # box_bottom is the lowest low reached since the swing high (100).
+        df = pd.DataFrame({
+            'high': [115, 108, 107, 106, 110],
+            'low':  [112, 103, 102, 100, 105],
+            'close': [114, 106, 104, 103, 109],
+        })
+        is_breakout, box_top, box_bottom, box_range_pct, direction = (
+            self.stats.findDarvasBoxBreakout(df, lookback_periods=5)
+        )
+        self.assertTrue(is_breakout)
+        self.assertEqual(box_top, 110)
+        self.assertEqual(box_bottom, 100)
+        self.assertEqual(direction, "up")
+
+    def test_findDarvasBoxBreakout_inside_box_is_not_a_breakout(self):
+        """A close still between box_bottom and box_top should not breakout."""
+        df = pd.DataFrame({
+            'high': [106, 108, 107, 106, 110],
+            'low':  [101, 103, 102, 100, 105],
+            'close': [104, 106, 104, 103, 109],
+        })
+        is_breakout, box_top, box_bottom, box_range_pct, direction = (
+            self.stats.findDarvasBoxBreakout(df, lookback_periods=5)
+        )
+        self.assertFalse(is_breakout)
+        self.assertIsNone(direction)
+
+    def test_findDarvasBoxBreakout_rejects_box_outside_size_range(self):
+        """A box tighter than min_box_pct should be rejected (no breakout)."""
+        df = pd.DataFrame({
+            'high': [100.4, 100.3, 100.4, 100.6],
+            'low':  [100.1, 100.0, 100.0, 100.0],
+            'close': [100.2, 100.2, 100.1, 100.5],
+        })
+        is_breakout, box_top, box_bottom, box_range_pct, direction = (
+            self.stats.findDarvasBoxBreakout(df, lookback_periods=5, min_box_pct=2.0)
+        )
+        self.assertFalse(is_breakout)
+        self.assertIsNone(direction)
+
     def test_findHigherOpens(self):
         """Test findHigherOpens method."""
         df = pd.DataFrame({


### PR DESCRIPTION
## Summary
Addresses #167 — adds `findDarvasBoxBreakout` to `ScreeningStatistics.py`, following the same style as the existing `findFibonacciRetracement`/`findFibonacciExtension` scanner methods.

**Box formation** (from a configurable lookback window, excluding today's own row so today can be evaluated against it):
- Box top: the swing high within the historical window
- Box bottom: the lowest low reached since that swing high (the consolidation that followed the peak)

**Breakout detection:** returns a direction (`"up"`/`"down"`/`None`) based on whether today's close is above the box top, below the box bottom, or still inside the box.

**Customizable parameters:** `lookback_periods`, `min_box_pct`/`max_box_pct` to bound valid box sizes (a box smaller than `min_box_pct` or larger than `max_box_pct` is rejected rather than reported as a valid breakout).

I did not implement the "visual indicators on the chart" part of the request — happy to follow up on that separately if useful, or if there's a preferred place to hook that into the existing chart/image output.

## Note
While exploring this, I noticed `findFibonacciRetracement`/`findFibonacciExtension` (issue #187) already exist in `ScreeningStatistics.py` on `main` but aren't wired into the scanner menu yet — flagged that separately on #187 in case that's in-progress work, rather than duplicating it here.

## Testing
- Added unit tests in `test/ScreeningStatistics_test.py` (`TestUncoveredMethods`): a clean breakout above box top, a close still inside the box, and a box rejected for being outside the min/max size bounds.
- Ran the full `TestUncoveredMethods` class locally: 35 passed, 0 failures.
- `flake8 --select=E9,F63,F7,F82` on both changed files: 0 errors.